### PR TITLE
Expose exports from esbuild entrypoint file, fix use strict breaking static diagram

### DIFF
--- a/src/static/interface.ts
+++ b/src/static/interface.ts
@@ -5,10 +5,13 @@ import {
 } from "../shared/ParamsInterface";
 import update from "./render";
 
-render = function (params: ParamsResponse, storedParams: StoredParamsResponse) {
+export const render = function (
+    params: ParamsResponse,
+    storedParams: StoredParamsResponse,
+) {
     return update(params, storedParams);
 };
 
-params = function () {
+export const params = function () {
     return paramsTypes;
 };

--- a/src/static/interface.ts
+++ b/src/static/interface.ts
@@ -5,13 +5,13 @@ import {
 } from "../shared/ParamsInterface";
 import update from "./render";
 
-export const render = function (
+export function render(
     params: ParamsResponse,
     storedParams: StoredParamsResponse,
 ) {
     return update(params, storedParams);
-};
+}
 
-export const params = function () {
+export function params() {
     return paramsTypes;
-};
+}

--- a/static-build.js
+++ b/static-build.js
@@ -95,6 +95,14 @@ try {
         mainFields: ["module", "main"],
         platform: "neutral",
         format: "iife",
+        // The iife format does not expose exports out of the entrypoint file
+        // We need the render and params methods to be exposed at the top level
+        // We can assign a name to the iife and pull them out from there.
+        // https://github.com/evanw/esbuild/issues/2277
+        globalName: "myDiagram",
+        footer: {
+            js: "var render = myDiagram.render; var params = myDiagram.params",
+        },
         // TS declarations in custom.d.ts should be sync'ed with loaders
         loader: {
             ".html": "text",


### PR DESCRIPTION
- [Fix] Remove undeclared variables which error in strict mode 

**Problem**
Recent PR https://github.com/ClearCalcs/custom-diagram-boilerplate/pull/30 added strict mode in tsconfig, which compiles to "use strict;". However, the static diagram `interface.ts` file has been relying implicit globals being created for render and params, which cause a strict mode error [link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var#).

**Approach**
The ESBuild configuration uses format IIFE (immediately invoked function) where all variable definitions are inside the scope of the function. We leverage the fact that exports out of the entrypoint files are stored as properties on the IIFE that can be accessed when a [globalName](https://esbuild.github.io/api/#global-name) has been configured for the function. We create a reference to the exports at the top-level using the https://esbuild.github.io/api/#footer API so these can be referenced on ClearCalcs servers.