### PR TITLE
Removed svgdotjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "parcel": "2.9.3",
         "posthtml-include": "1.7.4",
         "esbuild": "^0.18.17",
-        "@svgdotjs/svg.js": "^3.2.0",
         "svgdom": "^0.1.14",
         "@types/svgdom": "^0.1.2",
         "buffer": "^6.0.3",

--- a/src/static/main.html
+++ b/src/static/main.html
@@ -1,73 +1,71 @@
-<svg id="svg" viewBox="0 0 500 300">
-    <style>
-        body {
-            padding: 20px;
-        }
-        .logo {
-            margin: 0 auto 20px;
-            height: 5em;
-            display: block;
-        }
-        .content {
-            text-align: center;
+<style>
+    body {
+        padding: 20px;
+    }
+    .logo {
+        margin: 0 auto 20px;
+        height: 5em;
+        display: block;
+    }
+    .content {
+        text-align: center;
 
-            code {
-                background-color: #eee;
-                padding: 10px;
-                border-radius: 10px;
-            }
-
-            a {
-                text-underline-offset: 5px;
-            }
+        code {
+            background-color: #eee;
+            padding: 10px;
+            border-radius: 10px;
         }
 
-        #svg {
-            margin: 20px 0;
-            max-height: 400px;
+        a {
+            text-underline-offset: 5px;
         }
+    }
 
-        #circle,
-        #rect,
-        #triangle {
-            transition: fill 1s;
-        }
+    #svg {
+        margin: 20px 0;
+        max-height: 400px;
+    }
 
+    #circle,
+    #rect,
+    #triangle {
+        transition: fill 1s;
+    }
+
+    text {
+        font-size: 1em;
+    }
+
+    @media (min-width: 600px) {
         text {
-            font-size: 1em;
+            font-size: 0.8em;
         }
+    }
 
-        @media (min-width: 600px) {
-            text {
-                font-size: 0.8em;
-            }
+    @media (min-width: 1200px) {
+        text {
+            font-size: 0.5em;
         }
-
-        @media (min-width: 1200px) {
-            text {
-                font-size: 0.5em;
-            }
-        }
-    </style>
-    <g id="clearcalcs-logo" transform="scale(0.5) translate(100 -50)"></g>
-    <text x="50" y="100" font-family="Verdana" fill="black">
-        Welcome to the Static Diagram
-    </text>
-    <circle id="circle" cx="250" cy="175" r="50" fill="#ddd" stroke-width="3" />
-    <rect id="rect" x="80" y="125" width="100" height="100" fill="#ddd" />
-    <svg x="300" y="125">
-        <polygon id="triangle" points="50 0, 100 100, 0 100" fill="#ddd" />
-    </svg>
-    <text x="50" y="250" font-family="Verdana" fill="black">
-        Get started by reading the docs:
-    </text>
-    <!-- This link will not work as SVG rendered as Image in Sheet View -->
-    <text x="50" y="275">
-        <a
-            href="https://clearcalcs.github.io/custom-diagram-boilerplate/"
-            target="_blank"
-        >
-            https://clearcalcs.github.io/custom-diagram-boilerplate/
-        </a>
-    </text>
+    }
+</style>
+<g id="clearcalcs-logo" transform="scale(0.5) translate(100 -50)"></g>
+<text x="50" y="100" font-family="Verdana" fill="black">
+    Welcome to the Static Diagram
+</text>
+<circle id="circle" cx="250" cy="175" r="50" fill="#ddd" stroke-width="3" />
+<rect id="rect" x="80" y="125" width="100" height="100" fill="#ddd" />
+<svg x="300" y="125">
+    <polygon id="triangle" points="50 0, 100 100, 0 100" fill="#ddd" />
 </svg>
+<text x="50" y="250" font-family="Verdana" fill="black">
+    Get started by reading the docs:
+</text>
+<!-- This link will not work as SVG rendered as Image in Sheet View -->
+<text x="50" y="275">
+    <a
+        href="https://clearcalcs.github.io/custom-diagram-boilerplate/"
+        target="_blank"
+    >
+        https://clearcalcs.github.io/custom-diagram-boilerplate/
+    </a>
+</text>

--- a/src/static/render.ts
+++ b/src/static/render.ts
@@ -1,5 +1,4 @@
 import { createSVGWindow } from "svgdom";
-import { SVG, registerWindow } from "@svgdotjs/svg.js";
 import main_html from "./main.html";
 import logo_svg from "./assets/clearcalcs.svg";
 import {
@@ -7,20 +6,14 @@ import {
     StoredParamsResponse,
 } from "../shared/ParamsInterface";
 
-const windowObj = createSVGWindow();
-const documentObj = windowObj.document;
+// returns a window with a document and an svg root node (documentElement)
+const window = createSVGWindow();
+const svg = window.document.documentElement as SVGSVGElement;
+svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+svg.setAttribute("version", "1.1");
+svg.setAttribute("viewBox", "0 0 500 300");
 
-registerWindow(windowObj, documentObj);
-
-const CANVAS = SVG(documentObj.documentElement as SVGSVGElement);
-
-CANVAS.viewbox("0 0 500 300");
-CANVAS.svg(main_html);
-
-const logo_node = SVG();
-logo_node.svg(logo_svg);
-
-const SVG_ROOT = documentObj.querySelector("svg");
+svg.innerHTML = main_html;
 
 const defaultParams: ParamsResponse = {
     circleFill: "red",
@@ -33,15 +26,15 @@ export default function update(
     storedParams?: StoredParamsResponse,
 ) {
     const { circleFill, rectFill, triangleFill } = params || defaultParams;
-    SVG_ROOT!.querySelector("#circle")?.setAttribute("fill", circleFill);
+    svg.querySelector("#circle")?.setAttribute("fill", circleFill);
 
-    SVG_ROOT!.querySelector("#rect")?.setAttribute("fill", rectFill);
+    svg.querySelector("#rect")?.setAttribute("fill", rectFill);
 
-    SVG_ROOT!.querySelector("#triangle")?.setAttribute("fill", triangleFill);
-    SVG_ROOT!.querySelector("#clearcalcs-logo")?.appendChild(logo_node.node);
+    svg.querySelector("#triangle")?.setAttribute("fill", triangleFill);
+    svg.querySelector("#clearcalcs-logo")!.innerHTML = logo_svg;
     // // EXAMPLE (FROM USER INTERACTION)
     // if (!!storedParams?.circleBorder) {
-    //     SVG_ROOT!.querySelector("#circle")?.setAttribute("stroke", storedParams.circleBorder);
+    //     svg.querySelector("#circle")?.setAttribute("stroke", storedParams.circleBorder);
     // }
-    return CANVAS.svg();
+    return svg.outerHTML;
 }


### PR DESCRIPTION
refactor(remove svgdotjs) - svg.js is not required to use svgdom, if not using the svg.js API. 
    - Resolves unnecessary nested SVG element. 
    - Reduces bundle size from 407kB to 242kB for the starter example.
