### PR TITLE
Remove nested svg and svdot.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "parcel": "2.9.3",
         "posthtml-include": "1.7.4",
         "esbuild": "^0.18.17",
-        "@svgdotjs/svg.js": "^3.2.0",
         "svgdom": "^0.1.14",
         "@types/svgdom": "^0.1.2",
         "buffer": "^6.0.3",

--- a/src/static/main.html
+++ b/src/static/main.html
@@ -1,4 +1,9 @@
-<svg id="svg" viewBox="0 0 500 300">
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    id="svg"
+    viewBox="0 0 500 300"
+>
     <style>
         body {
             padding: 20px;


### PR DESCRIPTION
refactor(remove svgdotjs) - svg.js is not required to use svgdom, if not using the svg.js API.

- Resolves unnecessary nested SVG element, which is not correctly rendered in print using Weasyprint
- Reduces bundle size from 407kB to 242kB for the starter example.

supersedes https://github.com/ClearCalcs/custom-diagram-boilerplate/pull/54